### PR TITLE
fix: improve virtual media detection and ISO mounting

### DIFF
--- a/helm/values-example.yaml
+++ b/helm/values-example.yaml
@@ -169,7 +169,7 @@ datavolume:
   storage_class: "lvms-vg1"
   vm_update_timeout: "2m"
   iso_download_timeout: "30m"
-  helper_image: "alpine:latest"  # Change to private registry image if needed
+  helper_image: "registry.access.redhat.com/ubi8/ubi-minimal:latest"  # Change to private registry image if needed
 
 # =============================================================================
 # VOLUMES CONFIGURATION

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -286,7 +286,7 @@ datavolume:
   
   # Helper image for ISO copy operations
   # Change this to use a private registry image if needed
-  helper_image: "alpine:latest"
+  helper_image: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
 
 # =============================================================================
 # VOLUMES CONFIGURATION

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -238,7 +238,7 @@ func setDefaults() {
 	viper.SetDefault("datavolume.allow_insecure_tls", false)
 	viper.SetDefault("datavolume.vm_update_timeout", "30s")
 	viper.SetDefault("datavolume.iso_download_timeout", "30m")
-	viper.SetDefault("datavolume.helper_image", "alpine:latest")
+	viper.SetDefault("datavolume.helper_image", "registry.access.redhat.com/ubi8/ubi-minimal:latest")
 	viper.SetDefault("system_id_convention", "legacy") // Default to legacy for backward compatibility
 }
 


### PR DESCRIPTION
- Fix IsVirtualMediaInserted function with robust 4-step CD-ROM detection process
- Change ISO download from wget to curl for better compatibility
- Improve JSON patch indentation formatting

Based on improvements by @borball in commit 6fa7639bc763696e486e2d65bc1c0948da5ddfb6 Original issue: https://github.com/v1k0d3n/kubevirt-redfish/commit/6fa7639bc763696e486e2d65bc1c0948da5ddfb6

Fixes virtual media mounting issues where CD-ROM devices and associated PVCs were not being properly detected, leading to incorrect media insertion status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support ISO downloads over insecure HTTPS and extended timeouts for ISO import/download.

- Bug Fixes
  - More accurate detection of inserted virtual media via multi-step discovery and PVC validation.
  - More reliable insert/eject flows with retries, race-condition handling, and resilient PVC/volume checks.
  - Ensured cleanup of related resources after VM updates.

- Refactor
  - Expanded, clearer logging across virtual media operations and helper pod lifecycle.

- Chores
  - Default helper image switched to UBI-based image; ISO transfer changed from wget to curl.

- Tests
  - Added unit test validating virtual media volume-name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->