### PR TITLE
Adds a helper method that truncates resource names if these exceed 63 characters (k8s resource name limits)

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -21,10 +21,12 @@ package kubevirt
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -1740,7 +1742,7 @@ func (c *Client) insertVirtualMediaAsync(namespace, name, mediaID, imageURL stri
 		logger.Debug("DEBUG: Using CDI HTTP import approach for URL scheme %s", u.Scheme)
 		// CDI HTTP import for HTTP or valid HTTPS
 		logger.Info("Using CDI HTTP import for ISO")
-		volumeImportSourceName := fmt.Sprintf("%s-populator", dataVolumeName)
+		volumeImportSourceName := sanitizeResourceName(fmt.Sprintf("%s-populator", dataVolumeName))
 		logger.Debug("DEBUG: Generated volumeImportSourceName=%s", volumeImportSourceName)
 		volumeImportSource := &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -2858,4 +2860,17 @@ func (c *Client) isPVCUsable(pvc *corev1.PersistentVolumeClaim) bool {
 
 	// Lost or other states are not usable
 	return false
+}
+
+// sanitizeResourceName sanitizes a resource name to ensure it is a valid Kubernetes resource name
+// It truncates the resourceName to 63 characters if it's longer that that and ensures it ends with
+// alphanumeric character by appending "truncated" string, it also avoids name collisions by using a hash of the name
+func sanitizeResourceName(resourceName string) string {
+	if len(resourceName) <= 63 {
+		return resourceName
+	}
+	hash := sha256.Sum256([]byte(resourceName))
+	shortHash := new(big.Int).SetBytes(hash[:]).Text(36)[:5]
+
+	return resourceName[:49] + shortHash + "truncated"
 }

--- a/pkg/kubevirt/client_test.go
+++ b/pkg/kubevirt/client_test.go
@@ -3343,3 +3343,57 @@ func TestGetVMPowerStateNilClient(t *testing.T) {
 		t.Errorf("Expected power state 'Unknown', got '%s'", powerState)
 	}
 }
+
+// TestSanitizeResourceName tests the sanitizeResourceName function
+func TestSanitizeResourceName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "short name",
+			input:    "vm",
+			expected: "vm",
+		},
+		{
+			name:     "exactly 63 characters",
+			input:    "this-is-a-resource-name-with-63-characters-aaaaaaaaaaaaaaaaaaaa",
+			expected: "this-is-a-resource-name-with-63-characters-aaaaaaaaaaaaaaaaaaaa",
+		},
+		{
+			name:     "64 characters - should be truncated",
+			input:    "this-is-a-resource-name-with-64-characters-the-last-one-is-gone-",
+			expected: "this-is-a-resource-name-with-64-characters-the-la5fg6xtruncated",
+		},
+		{
+			name:     "> 64 characters - should be truncated",
+			input:    "this-is-a-resource-name-with-more-than-64-characters-and-it-must-be-truncated",
+			expected: "this-is-a-resource-name-with-more-than-64-charact2xwg2truncated",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := sanitizeResourceName(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, result)
+			}
+
+			// Additional validation: ensure the result is never longer than 63 characters
+			if len(result) > 63 {
+				t.Errorf("Result length %d exceeds maximum allowed length of 63", len(result))
+			}
+
+			// Additional validation: ensure the result is never longer than the input
+			if len(result) > len(tc.input) {
+				t.Errorf("Result length %d is longer than input length %d", len(result), len(tc.input))
+			}
+		})
+	}
+}


### PR DESCRIPTION
When creating k8s resources, we want to ensure that these do not exceed 63 characters, otherwise admission controllers will reject the request.

The implemented method will only truncate the resourceName if it exceeds the 63 characters, and for now it just returns the last 54 chars + the "truncated" string. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents import failures by automatically sanitizing overly long Kubernetes resource names for volume import sources, ensuring they meet length constraints even with long DataVolume names.
- Tests
  - Added comprehensive test coverage for resource name sanitization across edge cases (empty, exact limit, and over-limit inputs) to ensure consistent, valid behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->