### PR TITLE
fix: sanitize PVC and helper pod names to prevent K8s validation errors

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -1513,7 +1513,9 @@ func (c *Client) insertVirtualMediaAsync(namespace, name, mediaID, imageURL stri
 
 	// Generate unique PVC name with timestamp and random suffix to avoid conflicts
 	dataVolumeName := c.generateUniquePVCName(name)
-	logger.Debug("DEBUG: Generated unique dataVolumeName=%s", dataVolumeName)
+	// Sanitize the PVC name to ensure it doesn't exceed Kubernetes 63-character limit
+	dataVolumeName = sanitizeResourceName(dataVolumeName)
+	logger.Debug("DEBUG: Generated unique dataVolumeName=%s (sanitized to %d chars)", dataVolumeName, len(dataVolumeName))
 
 	// First, create the CD-ROM device in the VM spec
 	// Use lowercase device name for KubeVirt compatibility
@@ -1927,7 +1929,9 @@ func (c *Client) copyISOToPVC(namespace, dataVolumeName, imageURL, isoDownloadTi
 	// Use timestamp to make pod name unique and avoid race conditions
 	timestamp := time.Now().Unix()
 	helperPodName := fmt.Sprintf("copy-iso-%s-%d", dataVolumeName, timestamp)
-	logger.Debug("DEBUG: Generated unique helper pod name=%s", helperPodName)
+	// Sanitize the pod name to ensure it doesn't exceed Kubernetes 63-character limit
+	helperPodName = sanitizeResourceName(helperPodName)
+	logger.Debug("DEBUG: Generated unique helper pod name=%s (sanitized to %d chars)", helperPodName, len(helperPodName))
 
 	// Check if helper pod already exists before creating
 	existingPod, err := c.kubernetesClient.CoreV1().Pods(namespace).Get(context.Background(), helperPodName, metav1.GetOptions{})

--- a/pkg/kubevirt/client_test.go
+++ b/pkg/kubevirt/client_test.go
@@ -3397,3 +3397,142 @@ func TestSanitizeResourceName(t *testing.T) {
 		})
 	}
 }
+
+// TestGenerateUniquePVCNameLength tests that generated PVC names don't exceed 63 characters
+// This verifies the fix for the race condition bug where long VM names caused invalid PVC names
+func TestGenerateUniquePVCNameLength(t *testing.T) {
+	client := &Client{}
+
+	testCases := []struct {
+		name           string
+		vmName         string
+		expectedMaxLen int
+	}{
+		{
+			name:           "short VM name",
+			vmName:         "vm-01",
+			expectedMaxLen: 63,
+		},
+		{
+			name:           "medium VM name",
+			vmName:         "test-virtual-machine-with-medium-length-name",
+			expectedMaxLen: 63,
+		},
+		{
+			name:           "long VM name that would exceed limit",
+			vmName:         "ztp-cluster-with-a-very-long-name-that-exceeds-kubernetes-limits",
+			expectedMaxLen: 63,
+		},
+		{
+			name:           "extremely long VM name",
+			vmName:         "this-is-an-extremely-long-virtual-machine-name-that-definitely-exceeds-the-kubernetes-63-character-limit-for-resource-names",
+			expectedMaxLen: 63,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Generate the PVC name
+			pvcName := client.generateUniquePVCName(tc.vmName)
+
+			// Apply sanitization (as done in the actual code)
+			sanitizedPvcName := sanitizeResourceName(pvcName)
+
+			// Verify the sanitized name doesn't exceed the limit
+			if len(sanitizedPvcName) > tc.expectedMaxLen {
+				t.Errorf("Sanitized PVC name length %d exceeds maximum allowed length of %d. Name: %s",
+					len(sanitizedPvcName), tc.expectedMaxLen, sanitizedPvcName)
+			}
+
+			// Verify the name is valid (ends with alphanumeric)
+			lastChar := sanitizedPvcName[len(sanitizedPvcName)-1]
+			if !((lastChar >= 'a' && lastChar <= 'z') || (lastChar >= '0' && lastChar <= '9')) {
+				t.Errorf("Sanitized PVC name does not end with alphanumeric character: %s", sanitizedPvcName)
+			}
+
+			// For debugging: show the transformation
+			if len(pvcName) > 63 {
+				t.Logf("Original PVC name (%d chars): %s", len(pvcName), pvcName)
+				t.Logf("Sanitized PVC name (%d chars): %s", len(sanitizedPvcName), sanitizedPvcName)
+			}
+		})
+	}
+}
+
+// TestHelperPodNameLength tests that helper pod names don't exceed 63 characters
+// This verifies that the fix also applies to helper pod names
+func TestHelperPodNameLength(t *testing.T) {
+	testCases := []struct {
+		name           string
+		dataVolumeName string
+		timestamp      int64
+	}{
+		{
+			name:           "short datavolume name",
+			dataVolumeName: "vm-01-bootiso-1234567890-123456",
+			timestamp:      1729468000,
+		},
+		{
+			name:           "datavolume at 63-char limit",
+			dataVolumeName: "very-long-vm-name-bootiso-1234567890-1234567trunc12345678901",
+			timestamp:      1729468000,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Simulate helper pod name generation
+			helperPodName := fmt.Sprintf("copy-iso-%s-%d", tc.dataVolumeName, tc.timestamp)
+
+			// Apply sanitization (as done in the actual code)
+			sanitizedHelperPodName := sanitizeResourceName(helperPodName)
+
+			// Verify the sanitized name doesn't exceed the limit
+			if len(sanitizedHelperPodName) > 63 {
+				t.Errorf("Sanitized helper pod name length %d exceeds maximum allowed length of 63. Name: %s",
+					len(sanitizedHelperPodName), sanitizedHelperPodName)
+			}
+
+			// Verify the name is valid (ends with alphanumeric)
+			lastChar := sanitizedHelperPodName[len(sanitizedHelperPodName)-1]
+			if !((lastChar >= 'a' && lastChar <= 'z') || (lastChar >= '0' && lastChar <= '9')) {
+				t.Errorf("Sanitized helper pod name does not end with alphanumeric character: %s", sanitizedHelperPodName)
+			}
+
+			// For debugging: show the transformation
+			if len(helperPodName) > 63 {
+				t.Logf("Original helper pod name (%d chars): %s", len(helperPodName), helperPodName)
+				t.Logf("Sanitized helper pod name (%d chars): %s", len(sanitizedHelperPodName), sanitizedHelperPodName)
+			}
+		})
+	}
+}
+
+// TestPVCNameUniqueness tests that sanitized PVC names remain unique
+// This ensures that the sanitization doesn't cause collisions
+func TestPVCNameUniqueness(t *testing.T) {
+	client := &Client{}
+	vmName := "ztp-cluster-with-a-very-long-name-that-exceeds-kubernetes-limits"
+
+	// Generate multiple PVC names for the same VM (simulating concurrent operations)
+	names := make(map[string]int)
+
+	for i := 0; i < 100; i++ {
+		pvcName := client.generateUniquePVCName(vmName)
+		sanitizedName := sanitizeResourceName(pvcName)
+
+		names[sanitizedName]++
+
+		// Verify uniqueness
+		if names[sanitizedName] > 1 {
+			t.Errorf("Collision detected! Name %s generated %d times", sanitizedName, names[sanitizedName])
+		}
+
+		// Small delay to ensure timestamp changes
+		if i%10 == 0 {
+			time.Sleep(1 * time.Millisecond)
+		}
+	}
+
+	t.Logf("Generated %d unique sanitized PVC names", len(names))
+}


### PR DESCRIPTION
Fixes regression from commit 0307f41 where sanitizeResourceName() was only applied to volumeImportSourceName but not to the actual PVC name or helper pod names.

When VM names were long, generated PVC names could exceed Kubernetes' 63-character limit, causing:
- API validation errors
- Retry loops creating multiple PVCs
- Storage space consumption from orphaned resources
- Race conditions with volumeBindingMode: WaitForFirstConsumer

Changes:
- Apply sanitizeResourceName() to dataVolumeName after generation
- Apply sanitizeResourceName() to helperPodName after generation
- Add comprehensive test coverage for name length validation
- Add uniqueness tests for concurrent operations

Tested with VM names from empty to >200 characters. All existing tests pass with no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added name sanitization to enforce Kubernetes 63-character naming limits for generated resources, ensuring compatibility and preventing naming failures.

* **Tests**
  * Added tests validating name length constraints and collision resistance for resource naming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->