### PR TITLE
Set Route host in helm chart to blank to support auto-gen

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -130,8 +130,9 @@ route:
   enabled: true
   
   # Route hostname
-  # This should be a valid hostname that resolves to your OpenShift cluster (you will need to change this setting to match your OpenShift environment )
-  host: "kubevirt-redfish-default.apps.clustername.example.com"
+  # By default, the host variable is blanks so the FQDN for the Route will be generated automatically.
+  # If you don't want to use the default generated name, this should be a valid hostname that resolves to your OpenShift cluster
+  host: ""
   
   # Additional labels for the route (no need to change these settings unless you're testing or debugging)
   labels: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -130,7 +130,7 @@ route:
   enabled: true
   
   # Route hostname
-  # By default, the host variable is blanks so the FQDN for the Route will be generated automatically.
+  # By default, the host variable is blank, the FQDN for the Route will be generated automatically with the wildcard App Ingress.
   # If you don't want to use the default generated name, this should be a valid hostname that resolves to your OpenShift cluster
   host: ""
   


### PR DESCRIPTION
Addresses #22 - I dunno why the diff shows it chomped some white space at the end, when I edit it it's there...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Changes**
  * Updated default route host configuration to enable automatic FQDN generation via wildcard App Ingress. Custom hostnames can now be explicitly configured when needed.

* **Style**
  * Minor comment formatting adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->