### PR TITLE
Fix duplicate 'name' field in Helm chart volumes configuration

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -91,10 +91,10 @@ spec:
       volumes:
         {{- if .config }}
         - name: {{ .config.name }}
-          {{- toYaml .config | nindent 10 }}
+          {{- toYaml (omit .config "name") | nindent 10 }}
         {{- end }}
         {{- if .temp }}
         - name: {{ .temp.name }}
-          {{- toYaml .temp | nindent 10 }}
+          {{- toYaml (omit .temp "name") | nindent 10 }}
         {{- end }}
       {{- end }} 


### PR DESCRIPTION
The Helm template was generating duplicate 'name' keys in the volumes section by explicitly setting the name and then using toYaml on the entire volume object which already contained the name field.

This fix uses the 'omit' function to exclude the 'name' field when rendering the volume configuration, preventing YAML unmarshal errors.

Fixes #25