### PR TITLE
SetBootOrder - recompute the order for all disks

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -1210,8 +1210,9 @@ func (c *Client) GetVMBootOptions(namespace, name string) (map[string]interface{
 	return bootOptions, nil
 }
 
-// SetVMBootOptions sets boot options of a VirtualMachine
-func (c *Client) SetVMBootOptions(namespace, name string, options map[string]interface{}) error {
+// RecordVMBootOptionsAsAnnotations stores the boot options of a VirtualMachine
+// This is needed to support Once and Next boot logic in the future.
+func (c *Client) RecordVMBootOptionsAsAnnotations(namespace, name string, options map[string]interface{}) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
@@ -2297,7 +2298,9 @@ func (c *Client) IsDataVolumeReady(namespace, name string) (bool, error) {
 	return false, nil
 }
 
-// SetBootOrder sets the boot order for a VM to prioritize CD-ROM when boot target is CD
+// SetBootOrder sets the boot order for a VM to prioritize the selected device.
+// CD-ROM when boot target is CD, but this also keeps disk as the backup device so media ejection is handled
+// The first disk when boot target is Hdd
 func (c *Client) SetBootOrder(namespace, name, bootTarget string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
@@ -2313,36 +2316,13 @@ func (c *Client) SetBootOrder(namespace, name, bootTarget string) error {
 	// Update VM with boot order configuration
 	vmCopy := vm.DeepCopy()
 
-	// Get current devices
-	devices, found, err := unstructured.NestedMap(vmCopy.Object, "spec", "template", "spec", "domain", "devices")
-	if err == nil && found {
-		// Update disk boot order
-		if disks, found := devices["disks"].([]interface{}); found {
-			for i, disk := range disks {
-				if diskMap, ok := disk.(map[string]interface{}); ok {
-					if diskName, found := diskMap["name"].(string); found {
-						if bootTarget == "Cd" && diskName == "cdrom0" {
-							// Set CD-ROM as first boot device
-							diskMap["bootOrder"] = int64(1)
-							logger.Info("Set CD-ROM %s as first boot device", diskName)
-						} else if diskName == "disk1" {
-							// Set main disk as second boot device
-							diskMap["bootOrder"] = int64(2)
-							logger.Info("Set disk %s as second boot device", diskName)
-						}
-					}
-				}
-				// Update the disk in the slice
-				disks[i] = disk
-			}
-			devices["disks"] = disks
-		}
-
-		// Update devices in VM
-		err = unstructured.SetNestedMap(vmCopy.Object, devices, "spec", "template", "spec", "domain", "devices")
-		if err != nil {
-			return fmt.Errorf("failed to update VM devices: %w", err)
-		}
+	// Collect current volumes and detect their type
+	// This is needed, because the device list does not provide enough
+	// information about disk type and there are disks that are not bootable
+	// like cloud init.
+	err = c.modifyVmBootOrder(vmCopy, bootTarget)
+	if err != nil {
+		return err
 	}
 
 	// Update VM
@@ -2358,6 +2338,90 @@ func (c *Client) SetBootOrder(namespace, name, bootTarget string) error {
 	}
 
 	logger.Info("Successfully set boot order to %s for VM %s/%s", bootTarget, namespace, name)
+	return nil
+}
+
+func (*Client) modifyVmBootOrder(vmCopy *unstructured.Unstructured, bootTarget string) error {
+	const (
+		HDD   = "hdd"
+		CDROM = "cd"
+	)
+
+	volumeTypes := map[string]string{}
+	cdsFound := 0
+	if volumesList, found, err := unstructured.NestedSlice(vmCopy.Object, "spec", "template", "spec", "volumes"); err == nil && found {
+		// Collect current boot devices
+
+		for _, volumeEntry := range volumesList {
+			if volume, found := volumeEntry.(map[string]interface{}); found {
+				volumeName, found := volume["name"].(string)
+				if !found {
+					continue
+				}
+
+				// Heuristic for catching autoimported cdroms
+				if strings.HasPrefix(volumeName, "cdrom") {
+					cdsFound += 1
+					volumeTypes[volumeName] = CDROM
+					continue
+				}
+
+				// Two basic disk types are recognized
+				// dataVolume and containerDisk
+				if _, ok := volume["dataVolume"]; ok {
+					volumeTypes[volumeName] = HDD
+				}
+				if _, ok := volume["containerDisk"]; ok {
+					volumeTypes[volumeName] = HDD
+				}
+			}
+		}
+	}
+
+	// Get current devices
+	devices, found, err := unstructured.NestedMap(vmCopy.Object, "spec", "template", "spec", "domain", "devices")
+	if err == nil && found {
+		// Update disk boot order
+		if disks, found := devices["disks"].([]interface{}); found {
+			// Collect current boot devices
+			nextBootOrderPrimary := 1
+			nextBootOrderSecondary := 1
+			for i, disk := range disks {
+				if diskMap, ok := disk.(map[string]interface{}); ok {
+					if diskName, found := diskMap["name"].(string); found {
+						if volType, found := volumeTypes[diskName]; found && volType == CDROM && bootTarget == "Cd" {
+							// Set CD-ROMs as primary boot devices
+							diskMap["bootOrder"] = int64(nextBootOrderPrimary)
+							logger.Info("Set CD-ROM %s as primary boot device (order: %d)", diskName, nextBootOrderPrimary)
+							nextBootOrderPrimary += 1
+						} else if volType, found := volumeTypes[diskName]; found && volType == HDD && bootTarget == "Hdd" {
+							// Set disk as primary boot device
+							diskMap["bootOrder"] = int64(nextBootOrderPrimary)
+							logger.Info("Set disk %s as primary boot device (order: %d)", diskName, nextBootOrderPrimary)
+							nextBootOrderPrimary += 1
+						} else if volType, found := volumeTypes[diskName]; found && volType == HDD && bootTarget == "Cd" {
+							// Set main disk as secondary boot device
+							diskMap["bootOrder"] = int64(cdsFound + nextBootOrderSecondary)
+							logger.Info("Set disk %s as secondary boot device (order: %d)", diskName, cdsFound+nextBootOrderSecondary)
+							nextBootOrderSecondary += 1
+						} else {
+							// All other devices should have their boot order removed
+							delete(diskMap, "bootOrder")
+						}
+					}
+				}
+				// Update the disk in the slice
+				disks[i] = disk
+			}
+			devices["disks"] = disks
+		}
+
+		// Update devices in VM
+		err = unstructured.SetNestedMap(vmCopy.Object, devices, "spec", "template", "spec", "domain", "devices")
+		if err != nil {
+			return fmt.Errorf("failed to update VM devices: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/kubevirt/client_test.go
+++ b/pkg/kubevirt/client_test.go
@@ -630,7 +630,7 @@ func TestClient_SetVMBootOptions(t *testing.T) {
 	}
 
 	// Test boot options setting failure - should return error, not panic
-	err := client.SetVMBootOptions("test-namespace", "test-vm", options)
+	err := client.RecordVMBootOptionsAsAnnotations("test-namespace", "test-vm", options)
 	if err == nil {
 		t.Error("Expected error when dynamic client is nil")
 	}
@@ -2469,7 +2469,7 @@ func TestSetVMBootOptionsReal(t *testing.T) {
 	}
 
 	// Test that SetVMBootOptions returns error when no client is available
-	err := client.SetVMBootOptions("test-namespace", "test-vm", map[string]interface{}{
+	err := client.RecordVMBootOptionsAsAnnotations("test-namespace", "test-vm", map[string]interface{}{
 		"BootSourceOverrideEnabled": "Once",
 		"BootSourceOverrideTarget":  "Pxe",
 	})
@@ -2590,6 +2590,15 @@ func TestSetBootOrderLogic(t *testing.T) {
 									},
 								},
 							},
+							"volumes": []interface{}{
+								map[string]interface{}{
+									"name": "cdrom0",
+								},
+								map[string]interface{}{
+									"name":       "disk1",
+									"dataVolume": map[string]interface{}{},
+								},
+							},
 						},
 					},
 				},
@@ -2597,6 +2606,89 @@ func TestSetBootOrderLogic(t *testing.T) {
 			expected: map[string]interface{}{
 				"cdrom0": int64(1),
 				"disk1":  int64(2),
+			},
+		},
+		{
+			name:       "Set CD-ROM as first boot device when boot 1 taken",
+			bootTarget: "Cd",
+			vmSpec: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"devices": map[string]interface{}{
+									"disks": []interface{}{
+										map[string]interface{}{
+											"name": "cdrom0",
+										},
+										map[string]interface{}{
+											"name":      "disk1",
+											"bootOrder": int64(1),
+										},
+									},
+								},
+							},
+							"volumes": []interface{}{
+								map[string]interface{}{
+									"name": "cdrom0",
+								},
+								map[string]interface{}{
+									"name":       "disk1",
+									"dataVolume": map[string]interface{}{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"cdrom0": int64(1),
+				"disk1":  int64(2),
+			},
+		},
+		{
+			name:       "Set CD-ROM as first boot device, ignore cloudInit",
+			bootTarget: "Cd",
+			vmSpec: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"devices": map[string]interface{}{
+									"disks": []interface{}{
+										map[string]interface{}{
+											"name": "cdrom0",
+										},
+										map[string]interface{}{
+											"name": "disk1",
+										},
+										map[string]interface{}{
+											"name": "cloudinitdisk",
+										},
+									},
+								},
+							},
+							"volumes": []interface{}{
+								map[string]interface{}{
+									"name": "cdrom0",
+								},
+								map[string]interface{}{
+									"name":       "disk1",
+									"dataVolume": map[string]interface{}{},
+								},
+								map[string]interface{}{
+									"name":             "cloudinitdisk",
+									"cloudInitNoCloud": map[string]interface{}{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"cdrom0":        int64(1),
+				"disk1":         int64(2),
+				"cloudinitdisk": nil,
 			},
 		},
 		{
@@ -2618,16 +2710,72 @@ func TestSetBootOrderLogic(t *testing.T) {
 									},
 								},
 							},
+							"volumes": []interface{}{
+								map[string]interface{}{
+									"name": "cdrom0",
+								},
+								map[string]interface{}{
+									"name":       "disk1",
+									"dataVolume": map[string]interface{}{},
+								},
+							},
 						},
 					},
 				},
 			},
 			expected: map[string]interface{}{
 				"cdrom0": nil,
-				"disk1":  int64(2),
+				"disk1":  int64(1),
+			},
+		},
+		{
+			name:       "Set disk as first boot device ignore cloud init",
+			bootTarget: "Hdd",
+			vmSpec: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"devices": map[string]interface{}{
+									"disks": []interface{}{
+										map[string]interface{}{
+											"name": "cdrom0",
+										},
+										map[string]interface{}{
+											"name": "disk1",
+										},
+										map[string]interface{}{
+											"name": "cloudinitdisk",
+										},
+									},
+								},
+							},
+							"volumes": []interface{}{
+								map[string]interface{}{
+									"name": "cdrom0",
+								},
+								map[string]interface{}{
+									"name":       "disk1",
+									"dataVolume": map[string]interface{}{},
+								},
+								map[string]interface{}{
+									"name":             "cloudinitdisk",
+									"cloudInitNoCloud": map[string]interface{}{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"cdrom0":        nil,
+				"disk1":         int64(1),
+				"cloudinitdisk": nil,
 			},
 		},
 	}
+
+	client := Client{}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2636,33 +2784,20 @@ func TestSetBootOrderLogic(t *testing.T) {
 			vm.SetUnstructuredContent(tc.vmSpec)
 
 			// Simulate the boot order logic
-			devices, found, err := unstructured.NestedMap(vm.Object, "spec", "template", "spec", "domain", "devices")
-			if err == nil && found {
-				if disks, found := devices["disks"].([]interface{}); found {
-					for i, disk := range disks {
-						if diskMap, ok := disk.(map[string]interface{}); ok {
-							if diskName, found := diskMap["name"].(string); found {
-								if tc.bootTarget == "Cd" && diskName == "cdrom0" {
-									// Set CD-ROM as first boot device
-									diskMap["bootOrder"] = int64(1)
-								} else if diskName == "disk1" {
-									// Set main disk as second boot device
-									diskMap["bootOrder"] = int64(2)
-								}
-							}
-						}
-						// Update the disk in the slice
-						disks[i] = disk
-					}
-					devices["disks"] = disks
-				}
-			}
+			client.modifyVmBootOrder(vm, tc.bootTarget)
 
 			// Verify the results
+			devices, found, err := unstructured.NestedMap(vm.Object, "spec", "template", "spec", "domain", "devices")
+			if !found || err != nil {
+				t.Errorf("modified VM has no devices: found:%v err:%v", found, err)
+			}
+
+			testedDisks := map[string]bool{}
 			if disks, found := devices["disks"].([]interface{}); found {
 				for _, disk := range disks {
 					if diskMap, ok := disk.(map[string]interface{}); ok {
 						if diskName, found := diskMap["name"].(string); found {
+							testedDisks[diskName] = true
 							if expectedOrder, exists := tc.expected[diskName]; exists {
 								if actualOrder, found := diskMap["bootOrder"]; found {
 									if actualOrder != expectedOrder {
@@ -2674,6 +2809,12 @@ func TestSetBootOrderLogic(t *testing.T) {
 							}
 						}
 					}
+				}
+			}
+
+			for name := range tc.expected {
+				if _, ok := testedDisks[name]; !ok {
+					t.Errorf("Disk %s boot order was not checked. It was probably missing.", name)
 				}
 			}
 		})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1550,17 +1550,17 @@ func (s *Server) handleBootUpdate(w http.ResponseWriter, r *http.Request, system
 		}
 	}
 
-	// Update boot configuration
-	err := s.kubevirtClient.SetVMBootOptions(chassisConfig.Namespace, vmName, bootConfig)
+	// Persist VM boot configuration in annotations
+	err := s.kubevirtClient.RecordVMBootOptionsAsAnnotations(chassisConfig.Namespace, vmName, bootConfig)
 	if err != nil {
 		logger.Error("Failed to update boot configuration for VM %s: %v", vmName, err)
 		s.sendInternalError(w, "Failed to update boot configuration")
 		return
 	}
 
-	// If boot target is CD, also set boot order
+	// Recompute boot order
 	if bootTarget, found := bootConfig["bootSourceOverrideTarget"]; found {
-		if target, ok := bootTarget.(string); ok && target == "Cd" {
+		if target, ok := bootTarget.(string); ok {
 			// Use a recover mechanism to prevent panics from crashing the server
 			func() {
 				defer func() {


### PR DESCRIPTION
This does not handle PXE, but we are not interested in that one yet.

Fixes: #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced boot order logic with intelligent device type detection (CD-ROM vs disk).
  * Boot configuration is now persisted through an annotation-based mechanism for improved flexibility.
  * Boot order computation is now applied more comprehensively when boot targets are specified.
  * Improved system resilience with better error handling during boot order updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->