### PR TITLE
Fix PVC cleanup: Get actual PVC name with unique identifier before deletion

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -2562,6 +2562,8 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 	}
 
 	// Delete VolumeImportSource
+	// Note: VolumeImportSource only exists when CDI import was used (HTTP, or HTTPS with valid certificate).
+	// If helper pod was used (HTTPS with allowInsecureTLS=true), no VolumeImportSource was created.
 	gvrVIS := schema.GroupVersionResource{
 		Group:    "cdi.kubevirt.io",
 		Version:  "v1beta1",
@@ -2571,7 +2573,7 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 	logger.Info("Deleting VolumeImportSource %s for ejected virtual media", volumeImportSourceName)
 	err = c.dynamicClient.Resource(gvrVIS).Namespace(namespace).Delete(ctx, volumeImportSourceName, metav1.DeleteOptions{})
 	if err != nil {
-		logger.Warning("Failed to delete VolumeImportSource %s: %v", volumeImportSourceName, err)
+		logger.Warning("Failed to delete VolumeImportSource %s: %v (this is expected if ISO was imported via helper pod instead of CDI)", volumeImportSourceName, err)
 		// Don't fail the operation if VolumeImportSource cleanup fails
 	} else {
 		logger.Info("Successfully deleted VolumeImportSource %s", volumeImportSourceName)

--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -2421,6 +2421,30 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 
 	logger.Debug("Current VM spec before ejection: %v", vm.Object)
 
+	// Get the actual PVC name from the volume BEFORE removing it from the VM
+	// This is necessary because PVC names have unique identifiers appended
+	var actualPVCName string
+	var actualVolumeImportSourceName string
+	volumes, found, err := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	if err == nil && found {
+		for _, volume := range volumes {
+			if volumeMap, ok := volume.(map[string]interface{}); ok {
+				if volumeName, found := volumeMap["name"].(string); found && volumeName == mediaID {
+					// Get PVC name from persistentVolumeClaim.claimName
+					if pvc, found := volumeMap["persistentVolumeClaim"].(map[string]interface{}); found {
+						if claimName, found := pvc["claimName"].(string); found {
+							actualPVCName = claimName
+							// Generate VolumeImportSource name based on actual PVC name
+							actualVolumeImportSourceName = sanitizeResourceName(fmt.Sprintf("%s-populator", actualPVCName))
+							logger.Info("Found actual PVC name %s and VolumeImportSource name %s for media %s", actualPVCName, actualVolumeImportSourceName, mediaID)
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
 	// Update VM to remove CD-ROM disk and volume reference
 	vmCopy := vm.DeepCopy()
 
@@ -2454,14 +2478,14 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 	devices["disks"] = disks
 
 	// Get current volumes and remove the volume reference
-	var volumes []interface{}
+	var volumesToKeep []interface{}
 	var foundVolume bool
 	if existingVolumes, found, err := unstructured.NestedSlice(vmCopy.Object, "spec", "template", "spec", "volumes"); err == nil && found {
 		for _, volume := range existingVolumes {
 			if volumeMap, ok := volume.(map[string]interface{}); ok {
 				if volumeName, found := volumeMap["name"].(string); found {
 					if volumeName != mediaID {
-						volumes = append(volumes, volume)
+						volumesToKeep = append(volumesToKeep, volume)
 					} else {
 						logger.Info("Removing volume reference %s from VM spec", mediaID)
 						foundVolume = true
@@ -2475,7 +2499,7 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 	}
 
 	// Update volumes in VM
-	err = unstructured.SetNestedSlice(vmCopy.Object, volumes, "spec", "template", "spec", "volumes")
+	err = unstructured.SetNestedSlice(vmCopy.Object, volumesToKeep, "spec", "template", "spec", "volumes")
 	if err != nil {
 		logger.Error("Failed to update VM volumes for %s/%s: %v", namespace, name, err)
 		return fmt.Errorf("failed to update VM volumes: %w", err)
@@ -2505,9 +2529,19 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 
 	logger.Info("Successfully updated VM %s/%s to remove CD-ROM and volume for media %s", namespace, name, mediaID)
 
-	// Clean up associated PVC and VolumeImportSource
-	pvcName := fmt.Sprintf("%s-bootiso", name)
-	volumeImportSourceName := fmt.Sprintf("%s-populator", pvcName)
+	// Clean up associated PVC and VolumeImportSource using the actual names
+	// If we couldn't find the actual PVC name, try the fallback name
+	pvcName := actualPVCName
+	if pvcName == "" {
+		pvcName = fmt.Sprintf("%s-bootiso", name)
+		logger.Warning("Could not determine actual PVC name from VM spec, using fallback name %s", pvcName)
+	}
+
+	volumeImportSourceName := actualVolumeImportSourceName
+	if volumeImportSourceName == "" {
+		volumeImportSourceName = sanitizeResourceName(fmt.Sprintf("%s-populator", pvcName))
+		logger.Warning("Could not determine actual VolumeImportSource name, using fallback name %s", volumeImportSourceName)
+	}
 
 	// Log PVC state before deletion
 	pvc, err := c.kubernetesClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})

--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -2424,7 +2424,6 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 	// Get the actual PVC name from the volume BEFORE removing it from the VM
 	// This is necessary because PVC names have unique identifiers appended
 	var actualPVCName string
-	var actualVolumeImportSourceName string
 	volumes, found, err := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
 	if err == nil && found {
 		for _, volume := range volumes {
@@ -2434,9 +2433,7 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 					if pvc, found := volumeMap["persistentVolumeClaim"].(map[string]interface{}); found {
 						if claimName, found := pvc["claimName"].(string); found {
 							actualPVCName = claimName
-							// Generate VolumeImportSource name based on actual PVC name
-							actualVolumeImportSourceName = sanitizeResourceName(fmt.Sprintf("%s-populator", actualPVCName))
-							logger.Info("Found actual PVC name %s and VolumeImportSource name %s for media %s", actualPVCName, actualVolumeImportSourceName, mediaID)
+							logger.Info("Found actual PVC name %s for media %s", actualPVCName, mediaID)
 							break
 						}
 					}
@@ -2537,11 +2534,8 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 		logger.Warning("Could not determine actual PVC name from VM spec, using fallback name %s - cleanup may be incomplete; check for orphaned PVCs with pattern '%s-bootiso-*'", pvcName, name)
 	}
 
-	volumeImportSourceName := actualVolumeImportSourceName
-	if volumeImportSourceName == "" {
-		volumeImportSourceName = sanitizeResourceName(fmt.Sprintf("%s-populator", pvcName))
-		logger.Warning("Could not determine actual VolumeImportSource name, using fallback name %s", volumeImportSourceName)
-	}
+	// Generate VolumeImportSource name based on PVC name using the -populator suffix convention
+	volumeImportSourceName := sanitizeResourceName(fmt.Sprintf("%s-populator", pvcName))
 
 	// Log PVC state before deletion
 	pvc, err := c.kubernetesClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})

--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -2534,7 +2534,7 @@ func (c *Client) EjectVirtualMedia(namespace, name, mediaID string) error {
 	pvcName := actualPVCName
 	if pvcName == "" {
 		pvcName = fmt.Sprintf("%s-bootiso", name)
-		logger.Warning("Could not determine actual PVC name from VM spec, using fallback name %s", pvcName)
+		logger.Warning("Could not determine actual PVC name from VM spec, using fallback name %s - cleanup may be incomplete; check for orphaned PVCs with pattern '%s-bootiso-*'", pvcName, name)
 	}
 
 	volumeImportSourceName := actualVolumeImportSourceName


### PR DESCRIPTION
Every time an ISO is unmounted,d a similar message is shown. This is because the PVC uses a unique identifier while the code is just trying to remove the default PVC name <name_of_the_node-bootiso (ex, ocp-agent-master-0-bootiso). The result is that the PV/PVC is still around. Actually, we end up with multiple orphaned bootiso PVs.

```
2025/12/23 13:37:10 2025-12-23T13:37:10.448Z INFO: Received POST request for VM ocp-agent-master-0 from 10.128.0.2:45834
2025/12/23 13:37:10 2025-12-23T13:37:10.639Z INFO: Ejecting virtual media cdrom0 for VM cnf77/ocp-agent-master-0
2025/12/23 13:37:10 2025-12-23T13:37:10.838Z INFO: Removing CD-ROM device cdrom0 from VM spec
2025/12/23 13:37:10 2025-12-23T13:37:10.838Z INFO: Removing volume reference cdrom0 from VM spec
2025/12/23 13:37:11 2025-12-23T13:37:11.054Z INFO: Successfully updated VM cnf77/ocp-agent-master-0 to remove CD-ROM and volume for media cdrom0
2025/12/23 13:37:11 2025-12-23T13:37:11.056Z WARNING: PVC ocp-agent-master-0-bootiso not found before deletion: persistentvolumeclaims "ocp-agent-master-0-bootiso" not found
2025/12/23 13:37:11 2025-12-23T13:37:11.056Z INFO: Deleting PVC ocp-agent-master-0-bootiso for ejected virtual media
**2025/12/23 13:37:11 2025-12-23T13:37:11.058Z WARNING: Failed to delete PVC ocp-agent-master-0-bootiso: persistentvolumeclaims "ocp-agent-master-0-bootiso" not found
2025/12/23 13:37:11 2025-12-23T13:37:11.058Z INFO: Deleting VolumeImportSource ocp-agent-master-0-bootiso-populator for ejected virtual media
2025/12/23 13:37:11 2025-12-23T13:37:11.238Z WARNING: Failed to delete VolumeImportSource ocp-agent-master-0-bootiso-populator: volumeimportsources.cdi.kubevirt.io "ocp-agent-master-0-bootiso-populator" not found**
```
This PR fixes PVC cleanup: Get the actual PVC name with a unique identifier before deletion:
    
    - Read actual PVC name from VM spec volumes before removing volume reference
    - Handle PVCs with unique identifiers (e.g., ocp-agent-master-2-bootiso-1767978022-735019)
    - Generate correct VolumeImportSource name based on actual PVC name
    - Add fallback to simple name if actual name cannot be determined
    - Fixes issue where PVC deletion failed because it used simple name instead of actual name with identifier

Notice, this PR has been built on top of #29  cc/ @MarSik


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Virtual media ejection now accurately identifies and cleans up associated resources in all scenarios
  * Improved fallback handling when expected resources are not found during cleanup operations
  * Added warnings for incomplete cleanup cases instead of hard failures, providing better visibility into potential issues

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->